### PR TITLE
memory efficient loading with pickle and dictionary merge functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+train/

--- a/char_split.py
+++ b/char_split.py
@@ -7,10 +7,14 @@ __author__ = 'don.tuggener@gmail.com, silvan.laube@fhnw.ch'
 import pickle
 import re
 import sys
+import os
 
 ngram_probs = None
 
 def init(file: str='ngram_probs.pickle'):
+    if os.path.dirname(file) == '':
+        file = os.path.join(os.path.dirname(__file__), file)
+    
     global ngram_probs
     ngram_probs = None  # allows earlier garbage collection if this isn't the first init call
 

--- a/char_split_train.py
+++ b/char_split_train.py
@@ -7,6 +7,7 @@ __author__ = 'don.tuggener@gmail.com'
 
 import re
 import sys
+import pickle
 from collections import defaultdict
 
 # Dicts for counting the ngrams
@@ -22,7 +23,7 @@ max_len = 20    # Maximum ngram length
 
 # Gather counts
 print('Words analyzed of max.', str(max_words))
-for line in open(sys.argv[1],'r'):
+for line in open(sys.argv[1], 'r', encoding='utf-8'):
 
     line = line.strip().lower()
     if '-' in line: 
@@ -60,14 +61,5 @@ start_ngrams = {k: v/all_ngrams[k] for k,v in start_ngrams.items() if v > 1}
 end_ngrams = {k: v/all_ngrams[k] for k,v in end_ngrams.items() if v > 1}
 in_ngrams = {k: v/all_ngrams[k] for k,v in in_ngrams.items() if v > 1}
 
-# Write dicts to python file
-with open('ngram_probs.py','w') as f:
-    f.write('prefix=')
-    f.write(str(dict(start_ngrams)))
-    f.write('\n')
-    f.write('infix=')
-    f.write(str(dict(in_ngrams)))
-    f.write('\n')    
-    f.write('suffix=')
-    f.write(str(dict(end_ngrams)))
-    f.write('\n')
+with open('ngram_probs.pickle', 'wb') as f:
+    pickle.dump({'prefix': dict(start_ngrams), 'infix': dict(in_ngrams), 'suffix': dict(end_ngrams)}, f, protocol=pickle.HIGHEST_PROTOCOL)

--- a/merge_ngram_probs.py
+++ b/merge_ngram_probs.py
@@ -1,0 +1,39 @@
+import sys
+import pickle
+
+with open(sys.argv[1], 'rb') as f:
+    data1 = pickle.load(f)
+with open(sys.argv[2], 'rb') as f:
+    data2 = pickle.load(f)
+
+data_merged = {'prefix': {}, 'infix': {}, 'suffix': {}}
+for _fix in ['prefix', 'infix', 'suffix']:
+    changes, amount, maxdiff, maxdiff_ngram = 0, 0.0, 0.0, ''
+
+    for ngram, prob in data1[_fix].items():
+        data_merged[_fix][ngram] = prob
+    for ngram, prob in data2[_fix].items():
+        # data_merged[_fix][ngram] = (data_merged[_fix].get(ngram, prob) + prob) / 2
+        if ngram not in data1[_fix] or prob == data1[_fix]:
+            data_merged[_fix][ngram] = prob
+
+        else: # if ngram in data1[_fix] and prob != data1[_fix][ngram]: 
+            data_merged[_fix][ngram] = (data_merged[_fix][ngram] + prob) / 2
+
+            # gather statistics of what changed
+            changes += 1
+            diff = abs(data1[_fix][ngram] - prob)
+            amount += diff
+            if diff > maxdiff:
+                maxdiff = diff
+                maxdiff_ngram = ngram + ' (' + str(data1[_fix][ngram]) + ' -> ' + str(prob) + ')'
+
+    print('changes:', changes)
+    print('amount:', amount)
+    print('avg change:', amount / changes)
+    print('maxdiff:', maxdiff)
+    print('maxdiff_ngram:', maxdiff_ngram)
+
+outfile = sys.argv[3] if len(sys.argv) > 3 else 'ngram_probs_merged.pickle'
+with open(outfile, 'wb') as f:
+    pickle.dump(data_merged, f, pickle.HIGHEST_PROTOCOL)


### PR DESCRIPTION
I trained your model with >6M words and the result turned out to be unloadable by Python. Memory consumption just keeps going higher until finally a memory error is raised. Therefore I tried another approach using pickle for serialization of the dictionaries which worked perfectly fine.

Also I introduced a simple merge script that is capable of merging two models (e.g. my own model with your provided pre-trained model which I included here as .pickle as well). It basically just loops through all ngrams and for those that appear in both files the result file will keep the average of both.

Also one can now specify a specific model using
```python
import char_split
char_split.init('my_model.pickle')
```
if you don't call `init()` at all it will be called with the provided model when `split_compound()` is invoked for the first time.

So in case you wish to include my improvements you are welcome to accept this PR.
The only "drawback" is that the pre-trained ngrams are not human readable anymore in the file directly, because pickle stores objects in binary format. However, once loaded in python, one can easily print it if someone wished to peek at the provided model.